### PR TITLE
fix: handle expired JWT tokens gracefully

### DIFF
--- a/src/main/java/io/spring/api/security/JwtTokenFilter.java
+++ b/src/main/java/io/spring/api/security/JwtTokenFilter.java
@@ -1,6 +1,7 @@
 package io.spring.api.security;
 
 import io.spring.core.service.JwtService;
+import io.spring.core.user.User;
 import io.spring.core.user.UserRepository;
 import java.io.IOException;
 import java.util.Collections;
@@ -9,54 +10,49 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-@SuppressWarnings("SpringJavaAutowiringInspection")
 public class JwtTokenFilter extends OncePerRequestFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(JwtTokenFilter.class);
+  private static final String AUTH_HEADER = "Authorization";
+  private static final String TOKEN_PREFIX = "Token ";
+
   @Autowired private UserRepository userRepository;
   @Autowired private JwtService jwtService;
-  private final String header = "Authorization";
 
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
-    getTokenString(request.getHeader(header))
-        .flatMap(token -> jwtService.getSubFromToken(token))
-        .ifPresent(
-            id -> {
-              if (SecurityContextHolder.getContext().getAuthentication() == null) {
-                userRepository
-                    .findById(id)
-                    .ifPresent(
-                        user -> {
-                          UsernamePasswordAuthenticationToken authenticationToken =
-                              new UsernamePasswordAuthenticationToken(
-                                  user, null, Collections.emptyList());
-                          authenticationToken.setDetails(
-                              new WebAuthenticationDetailsSource().buildDetails(request));
-                          SecurityContextHolder.getContext().setAuthentication(authenticationToken);
-                        });
-              }
-            });
-
-    filterChain.doFilter(request, response);
-  }
-
-  private Optional<String> getTokenString(String header) {
-    if (header == null) {
-      return Optional.empty();
-    } else {
-      String[] split = header.split(" ");
-      if (split.length < 2) {
-        return Optional.empty();
-      } else {
-        return Optional.ofNullable(split[1]);
-      }
+    String header = request.getHeader(AUTH_HEADER);
+    if (header == null || !header.startsWith(TOKEN_PREFIX)) {
+      filterChain.doFilter(request, response);
+      return;
     }
+
+    String token = header.substring(TOKEN_PREFIX.length());
+    try {
+      Optional<String> subOptional = jwtService.getSubFromToken(token);
+      if (subOptional.isPresent()) {
+        Optional<User> userOptional = userRepository.findById(subOptional.get());
+        if (userOptional.isPresent()) {
+          UsernamePasswordAuthenticationToken authToken =
+              new UsernamePasswordAuthenticationToken(
+                  userOptional.get(), null, Collections.emptyList());
+          authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+          SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+      }
+    } catch (Exception e) {
+      LOG.warn("JWT authentication failed for request {}: {}", request.getRequestURI(), e.getMessage());
+      SecurityContextHolder.clearContext();
+    }
+    filterChain.doFilter(request, response);
   }
 }


### PR DESCRIPTION
> **Migrated from GitLab MR !2**
> Author: @mason-cognition | Created: 2026-03-06T01:02:18.085Z | Original state: opened

## Problem
Expired JWT tokens cause a 500 Internal Server Error instead of a proper 401 Unauthorized response. The `JwtTokenFilter` was letting the `ExpiredJwtException` propagate unhandled.

## Fix
Wrap the token parsing in a try-catch block that:
1. Catches all JWT-related exceptions
2. Logs a warning with the request URI
3. Clears the security context
4. Allows the filter chain to continue (resulting in 401 from Spring Security)

Closes #2
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mbatchelor81/gitlab-migration/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
